### PR TITLE
Add the 'ShowItemName' configuration property

### DIFF
--- a/src/main/java/com/robomwm/prettysimpleshop/ConfigManager.java
+++ b/src/main/java/com/robomwm/prettysimpleshop/ConfigManager.java
@@ -27,6 +27,7 @@ public class ConfigManager
     private JavaPlugin instance;
     private FileConfiguration config;
     private boolean debug;
+    private ConfigurationSection showOffItemsFeatureSection;
     private ConfigurationSection messageSection;
     private ConfigurationSection tipSection;
     private Set<World> whitelistedWorlds = new HashSet<>();
@@ -38,7 +39,13 @@ public class ConfigManager
     {
         instance = plugin;
         config = instance.getConfig();
-        config.addDefault("showOffItems", true);
+
+        showOffItemsFeatureSection = config.getConfigurationSection("showOffItemsFeature");
+        if (showOffItemsFeatureSection == null)
+            showOffItemsFeatureSection = config.createSection("showOffItemsFeature");
+        showOffItemsFeatureSection.addDefault("enabled", true);
+        showOffItemsFeatureSection.addDefault("showItemsName", true);
+
         config.addDefault("showItemDetailsInActionBar", true);
         config.addDefault("deleteShopWhenBroken", false);
         config.addDefault("useWorldWhitelist", false);

--- a/src/main/java/com/robomwm/prettysimpleshop/PrettySimpleShop.java
+++ b/src/main/java/com/robomwm/prettysimpleshop/PrettySimpleShop.java
@@ -78,8 +78,8 @@ public class PrettySimpleShop extends JavaPlugin
                     return;
                 }
                 ShopListener shopListener = new ShopListener(plugin, shopAPI, economy, config);
-                if (config.getBoolean("showOffItems"))
-                    showoffItem = new ShowoffItem(plugin, shopAPI);
+                if (config.getBoolean("showOffItemsFeature.enabled"))
+                    showoffItem = new ShowoffItem(plugin, shopAPI, config.getBoolean("showOffItemsFeature.showItemsName"));
                 if (config.getBoolean("showItemDetailsInActionBar"))
                     new ActionBarItemDetails(plugin, shopAPI, economy);
                 if (config.getBoolean("deleteShopWhenBroken"))

--- a/src/main/java/com/robomwm/prettysimpleshop/feature/ShowoffItem.java
+++ b/src/main/java/com/robomwm/prettysimpleshop/feature/ShowoffItem.java
@@ -56,13 +56,15 @@ public class ShowoffItem implements Listener
     private File cacheFile;
     private Map<Location, Item> spawnedItems = new HashMap<>();
     private ConfigManager config;
+    private boolean showItemName;
 
-    public ShowoffItem(PrettySimpleShop plugin, ShopAPI shopAPI)
+    public ShowoffItem(PrettySimpleShop plugin, ShopAPI shopAPI, boolean showItemName)
     {
         this.plugin = plugin;
         config = plugin.getConfigManager();
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
         this.shopAPI = shopAPI;
+        this.showItemName = showItemName;
         cacheFile = new File(plugin.getDataFolder(), "chunksContainingShops.data");
         cache = YamlConfiguration.loadConfiguration(cacheFile);
         for (World world : plugin.getServer().getWorlds())
@@ -248,13 +250,16 @@ public class ShowoffItem implements Listener
         despawnItem(location);
         if (itemStack == null)
             return false;
-        String name = PrettySimpleShop.getItemName(itemStack); //TODO: make configurable
         itemStack.setAmount(1);
         itemStack.getItemMeta().setDisplayName(String.valueOf(ThreadLocalRandom.current().nextInt())); //Prevents merging (idea from SCS) though metadata might be sufficient? Though we could also just use the ItemMergeEvent too but this is probably simpler and more performant.
         Item item = location.getWorld().dropItem(location, itemStack);
         item.setPickupDelay(Integer.MAX_VALUE);
-        item.setCustomName(name);
-        item.setCustomNameVisible(true);
+        if (showItemName)
+        {
+            String name = PrettySimpleShop.getItemName(itemStack); //TODO: make configurable
+            item.setCustomName(name);
+            item.setCustomNameVisible(true);
+        }
         item.setVelocity(new Vector(0, 0.01, 0));
         item.setMetadata("NO_PICKUP", new FixedMetadataValue(plugin, this));
         spawnedItems.put(location, item);


### PR DESCRIPTION
This PR adds a very simple configuration option which allows to hide the custom name tag on top of preview items.