### PR TITLE
Use effectiveName fallback for item names

### DIFF
--- a/src/main/java/com/robomwm/prettysimpleshop/PrettySimpleShop.java
+++ b/src/main/java/com/robomwm/prettysimpleshop/PrettySimpleShop.java
@@ -10,6 +10,7 @@ import com.robomwm.prettysimpleshop.feature.ShowoffItem;
 import com.robomwm.prettysimpleshop.shop.ShopAPI;
 import com.robomwm.prettysimpleshop.shop.ShopListener;
 import net.milkbowl.vault.economy.Economy;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.RegisteredServiceProvider;
@@ -111,6 +112,16 @@ public class PrettySimpleShop extends JavaPlugin
             if (item.getItemMeta().hasItemName())
                 return item.getItemMeta().getItemName();
         }
+
+        try
+        {
+            String effectiveName = PlainTextComponentSerializer.plainText().serialize(item.effectiveName());
+            if (effectiveName != null && !effectiveName.isEmpty()
+                    && !effectiveName.equals(item.getTranslationKey())
+                    && !effectiveName.equals(item.getType().getTranslationKey()))
+                return effectiveName;
+        }
+        catch (Throwable ignored) {}
 
         return item.getType().name().toLowerCase().replace('_', ' ');
     }

--- a/src/main/java/com/robomwm/prettysimpleshop/PrettySimpleShop.java
+++ b/src/main/java/com/robomwm/prettysimpleshop/PrettySimpleShop.java
@@ -105,14 +105,6 @@ public class PrettySimpleShop extends JavaPlugin
         if (item == null)
             return "unknown item";
 
-        if (item.hasItemMeta())
-        {
-            if (item.getItemMeta().hasDisplayName())
-                return item.getItemMeta().getDisplayName();
-            if (item.getItemMeta().hasItemName())
-                return item.getItemMeta().getItemName();
-        }
-
         try
         {
             String effectiveName = PlainTextComponentSerializer.plainText().serialize(item.effectiveName());
@@ -122,6 +114,9 @@ public class PrettySimpleShop extends JavaPlugin
                 return effectiveName;
         }
         catch (Throwable ignored) {}
+
+        if (item.hasItemMeta() && item.getItemMeta().hasDisplayName())
+            return item.getItemMeta().getDisplayName();
 
         return item.getType().name().toLowerCase().replace('_', ' ');
     }

--- a/src/main/java/com/robomwm/prettysimpleshop/PrettySimpleShop.java
+++ b/src/main/java/com/robomwm/prettysimpleshop/PrettySimpleShop.java
@@ -9,14 +9,16 @@ import com.robomwm.prettysimpleshop.feature.DestroyShopOnBreak;
 import com.robomwm.prettysimpleshop.feature.ShowoffItem;
 import com.robomwm.prettysimpleshop.shop.ShopAPI;
 import com.robomwm.prettysimpleshop.shop.ShopListener;
-import net.milkbowl.vault.economy.Economy;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import net.kyori.adventure.translation.GlobalTranslator;
+import net.milkbowl.vault.economy.Economy;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.util.Locale;
 import java.util.concurrent.Callable;
 
 /**
@@ -107,11 +109,9 @@ public class PrettySimpleShop extends JavaPlugin
 
         try
         {
-            String effectiveName = PlainTextComponentSerializer.plainText().serialize(item.effectiveName());
-            if (effectiveName != null && !effectiveName.isEmpty()
-                    && !effectiveName.equals(item.getTranslationKey())
-                    && !effectiveName.equals(item.getType().getTranslationKey()))
-                return effectiveName;
+            String effectiveName = PlainTextComponentSerializer.plainText()
+                    .serialize(GlobalTranslator.render(item.effectiveName(), Locale.ENGLISH));
+            return effectiveName;
         }
         catch (Throwable ignored) {}
 


### PR DESCRIPTION
## Summary
- keep the existing string-first item-name logic
- try ItemStack#effectiveName() on Purpur/Paper
- fall back cleanly when Spigot lacks that path

## Verification
- mvn --batch-mode verify