### PR TITLE
Fix showoff item cleanup on chunk unload and double-chest handling

### DIFF
--- a/src/main/java/com/robomwm/prettysimpleshop/feature/ShowoffItem.java
+++ b/src/main/java/com/robomwm/prettysimpleshop/feature/ShowoffItem.java
@@ -160,7 +160,9 @@ public class ShowoffItem implements Listener
         while (locations.hasNext()) //can optimize later via mapping chunks if needed
         {
             Location location = locations.next();
-            if (location.getChunk() == event.getChunk())
+            if (location.getWorld().equals(event.getWorld())
+                    && (location.getBlockX() >> 4) == event.getChunk().getX()
+                    && (location.getBlockZ() >> 4) == event.getChunk().getZ())
             {
                 Item item = spawnedItems.get(location);
                 item.remove();
@@ -192,12 +194,15 @@ public class ShowoffItem implements Listener
             @Override
             public void run()
             {
-                InventoryHolder holder = ((Container)event.getBlock().getState()).getInventory().getHolder();
+                Container container = (Container)event.getBlock().getState();
+                if (!shopAPI.isShop(container))
+                    return;
+                InventoryHolder holder = container.getInventory().getHolder();
                 if (!(holder instanceof DoubleChest))
                     return;
                 DoubleChest doubleChest = (DoubleChest)holder;
                 despawnItem(((Chest)(doubleChest.getLeftSide())).getLocation().add(0.5, 1.2, 0.5));
-                despawnItem(((Chest)(doubleChest.getLeftSide())).getLocation().add(0.5, 1.2, 0.5));
+                despawnItem(((Chest)(doubleChest.getRightSide())).getLocation().add(0.5, 1.2, 0.5));
             }
         }.runTask(plugin);
     }


### PR DESCRIPTION
### Motivation

This PR started from a review request and then narrowed to only changes that are actually useful.

**User prompt:**  
“review https://github.com/MLG-Fortress/PrettySimpleShop/pull/34

tell me what it changes, and if each change is actually useful/needed or not.

then implement the definitely useful ones.”

**Assistant response (summary):**  
Reviewed PR #34, split changes into useful vs unnecessary/risky, and implemented only the clearly useful fixes.

---

### Conversation Summary (Prompt → Response)

**User prompt:**  
“if the shop has to be a chest or doublechest, and the stock has to fit in that chest or doublechest, how is it possible for it to exceed the 54 slots?”

**Assistant response (summary):**  
Agreed this cap is not needed in practice for chest/double-chest constrained stock, and reverted that clamp change.

---

**User prompt:**  
“as for location#getBlock in getContainer - check the git history/blame to see if that's intentional. I have a feeling it might've been to ensure the blockstate is loaded and it's not pulling from cache?”

**Assistant response (summary):**  
Checked history/blame and restored `location.getBlock();` instead of removing it casually. Also investigated upstream API/server sources; evidence suggests it may be a legacy/defensive call rather than strictly required, but keeping it is safer without a focused refactor.

---

**User prompt:**  
“for the despawn items - what if the placed block is not a shop? ... wouldn't this miss shops that are turned into doublechests with a non-shop chest block?”

**Assistant response (summary):**  
Investigated shop creation flow and double-chest resolution. Current logic using `shopAPI.isShop(container)` should still detect merged double chests when one side is already a shop, while avoiding non-shop cleanup.

---

**User prompt:**  
“print the commit where location#getblock was introduced. Also check if my prior question was correct or not...”

**Assistant response (summary):**  
Identified introduction commit as `f75f7058d8591b6d7b55179900867e97325054e0` and confirmed rationale analysis above.

---

### Final Scope in This PR

#### Kept (definitely useful)
- Fix `ShowoffItem` chunk-unload matching to compare world + chunk coordinates instead of chunk object identity.
- Fix double-chest despawn to remove both left and right showcase positions (instead of despawning left twice).
- Keep shop check gate so cleanup only runs for recognized shops.

#### Reverted / Not Included
- Removed 54-slot post-purchase inventory clamp (not needed under chest/double-chest stock constraints).
- Kept `location.getBlock();` in `ShopAPI#getContainer` (restored after history/blame review).