### PR TITLE
Remove redundant no-op call in ShopAPI#getContainer

### DIFF
--- a/src/main/java/com/robomwm/prettysimpleshop/shop/ShopAPI.java
+++ b/src/main/java/com/robomwm/prettysimpleshop/shop/ShopAPI.java
@@ -185,7 +185,6 @@ public class ShopAPI
      */
     public Container getContainer(Location location)
     {
-        location.getBlock();
         BlockState state = location.getBlock().getState();
         if (state instanceof Container)
             return (Container)state;


### PR DESCRIPTION
Something that ai reverted in #64 and I forgot to re-add.

### Motivation
- Remove a no-op `location.getBlock()` call in `ShopAPI#getContainer` to clean up dead code and silence static analysis warnings.

### Description
- Deleted the redundant `location.getBlock();` line and rely on `location.getBlock().getState()` to obtain the `BlockState` in `getContainer(Location)` with no behavioral change.

### Testing
- Ran project build and unit tests with `mvn test`, and the build and tests passed.